### PR TITLE
configure AWS SES for sending e-mails via SMTP

### DIFF
--- a/modules/aws/create-hosted-zone/README.md
+++ b/modules/aws/create-hosted-zone/README.md
@@ -21,3 +21,4 @@ module "create_hosted_zone" {
 | Name                      | Value Type | Description
 |---------------------------| ---------- | -----------
 |`zone_id`                  | String     | The created hosted zone ID.
+|`name_servers`             | Array      | The name servers for this zone.

--- a/modules/aws/create-hosted-zone/outputs.tf
+++ b/modules/aws/create-hosted-zone/outputs.tf
@@ -1,3 +1,7 @@
 output "zone_id" {
   value = "${aws_route53_zone.new_zone.zone_id}"
 }
+
+output "name_servers" {
+  value = "${aws_route53_zone.new_zone.name_servers}"
+}

--- a/modules/aws/smtp/README.md
+++ b/modules/aws/smtp/README.md
@@ -1,0 +1,56 @@
+# smtp
+
+Configures AWS SES to send e-mails via SMTP. Handles SPF and DKIM configuration.
+
+# Example
+
+```hcl
+module "zone" {
+    source = "./modules/aws/create-hosted-zone"
+    domain = "example.com"
+}
+
+module "mail" {
+    source = "./modules/aws/smtp"
+    domain = "example.com"
+    mx_subdomain = "mail"
+    zone_id = "${module.zone.zone_id}"
+}
+
+output "smtp_name_servers" {
+    value = ["${module.zone.name_servers}"]
+}
+
+output "smtp_server" {
+    value = "${module.smtp.smtp_server}"
+}
+
+output "smtp_user" {
+    value = "${module.smtp.smtp_username}"
+}
+
+output "smtp_password" {
+    value = "${module.smtp.smtp_password}"
+}
+```
+
+Note: Once the AWS name servers have been set in the domain registrar configuration, it can
+take up to 72 for Amazon to verify the SES domain. Once the domain is verified, a service
+limit increase request must be done to disable the SES sandbox and be able to send e-mails
+to unverified recipients, this process is documented in the [AWS SES sandbox documentation](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html).
+
+# Arguments
+
+| Name                      | Required | Value Type | Description
+|---------------------------| -------- | ---------- | -----------
+|`zone_id`                  | Yes      | String     | Zone in which the DNS records should be created.
+|`domain`                   | Yes      | String     | Sender domain name.
+|`mx_subdomain`             | No       | String     | MX record subdomain (default: mx).
+
+# Outputs
+
+| Name                      | Value Type | Description
+|---------------------------| ---------- | -----------
+|`smtp_server`              | String     | Hostname of the SMTP server to use for sending e-mails.
+|`smtp_username`            | String     | User name to connect to the SMTP server.
+|`smtp_password`            | String     | Password to connect to the SMTP server.

--- a/modules/aws/smtp/main.tf
+++ b/modules/aws/smtp/main.tf
@@ -1,0 +1,100 @@
+data "aws_region" "current" {}
+
+# Random ID generator
+resource "random_id" "username" {
+  keepers = {
+    zone_id = "${var.zone_id}"
+  }
+
+  byte_length = 6
+}
+
+# IAM user for SES SMTP
+resource "aws_iam_user" "smtp_user" {
+  name = "ses-smtp-${random_id.username.hex}"
+}
+
+# IAM policy to send emails via SMTP through SES
+resource "aws_iam_user_policy" "smtp_policy" {
+  name = "${aws_iam_user.smtp_user.name}-policy"
+  user = "${aws_iam_user.smtp_user.name}"
+
+  policy = <<EOF
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Effect":"Allow",
+      "Action":[
+        "ses:SendEmail",
+        "ses:SendRawEmail"
+      ],
+      "Resource":"*",
+      "Condition":{
+        "StringLike":{
+          "ses:FromAddress": "*@${var.domain}"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+# IAM access key for SES SMTP user
+resource "aws_iam_access_key" "smtp_access_key" {
+  user = "${aws_iam_user.smtp_user.name}"
+}
+
+# SES domain Identity
+resource "aws_ses_domain_identity" "identity" {
+  domain = "${var.domain}"
+}
+
+# SES domain DKIM
+resource "aws_ses_domain_dkim" "dkim" {
+  domain = "${aws_ses_domain_identity.identity.domain}"
+}
+
+# SES domain mail sender
+resource "aws_ses_domain_mail_from" "mail_from" {
+  domain           = "${aws_ses_domain_identity.identity.domain}"
+  mail_from_domain = "${var.mx_subdomain}.${aws_ses_domain_identity.identity.domain}"
+}
+
+# Route53 TXT record for SES validation
+resource "aws_route53_record" "ses_txt_record" {
+  zone_id = "${var.zone_id}"
+  name    = "_amazonses.${aws_ses_domain_identity.identity.domain}"
+  type    = "TXT"
+  ttl     = "600"
+  records = ["${aws_ses_domain_identity.identity.verification_token}"]
+}
+
+# Route53 MX record
+resource "aws_route53_record" "mx_record" {
+  zone_id = "${var.zone_id}"
+  name    = "${aws_ses_domain_mail_from.mail_from.mail_from_domain}"
+  type    = "MX"
+  ttl     = "600"
+  records = ["10 feedback-smtp.${data.aws_region.current.name}.amazonses.com"]
+}
+
+# Route53 TXT record for SPF
+resource "aws_route53_record" "spf_record" {
+  zone_id = "${var.zone_id}"
+  name    = "${aws_ses_domain_mail_from.mail_from.mail_from_domain}"
+  type    = "TXT"
+  ttl     = "600"
+  records = ["v=spf1 include:amazonses.com -all"]
+}
+
+# Route53 CNAME records for DKIM
+resource "aws_route53_record" "dkim_record" {
+  count   = 3
+  zone_id = "${var.zone_id}"
+  name    = "${element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index)}._domainkey.${aws_ses_domain_identity.identity.domain}"
+  type    = "CNAME"
+  ttl     = "600"
+  records = ["${element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}

--- a/modules/aws/smtp/outputs.tf
+++ b/modules/aws/smtp/outputs.tf
@@ -1,0 +1,11 @@
+output "smtp_server" {
+  value = "email-smtp.${data.aws_region.current.name}.amazonaws.com"
+}
+
+output "smtp_username" {
+  value = "${aws_iam_access_key.smtp_access_key.id}"
+}
+
+output "smtp_password" {
+  value = "${aws_iam_access_key.smtp_access_key.ses_smtp_password}"
+}

--- a/modules/aws/smtp/variables.tf
+++ b/modules/aws/smtp/variables.tf
@@ -1,0 +1,7 @@
+variable "zone_id" {}
+
+variable "domain" {}
+
+variable "mx_subdomain" {
+    default = "mx"
+}

--- a/modules/google/dns-rdir/main.tf
+++ b/modules/google/dns-rdir/main.tf
@@ -38,8 +38,8 @@ resource "google_compute_instance" "dns-rdir" {
   
   provisioner "remote-exec" {
     inline = [
-      "apt-get update"
-      "apt-get install -y tmux socat"
+      "apt-get update",
+      "apt-get install -y tmux socat",
       "tmux new -d \"socat udp4-recvfrom:53,reuseaddr,fork udp4-sendto:${element(var.redirect_to, count.index)}\""
     ]
 

--- a/modules/google/phishing-server/main.tf
+++ b/modules/google/phishing-server/main.tf
@@ -38,9 +38,9 @@ resource "google_compute_instance" "phishing-server" {
   
   provisioner "remote-exec" {
     inline = [
-      "apt-get update"
-      "apt-get install -y tmux apache2 certbot"
-      "a2enmod ssl"
+      "apt-get update",
+      "apt-get install -y tmux apache2 certbot",
+      "a2enmod ssl",
       "systemctl stop apache2"
     ]
 


### PR DESCRIPTION
This PR adds the ability to quickly setup an SMTP server for sending e-mails via AWS SES (for use in a phishing campaign, for example). It creates:
- an IAM user with a policy allowing it to only send e-mails from the given domain
- an IAM access key for the user (to connect to AWS SMTP server)
- route53 records for SES verification, MX domain, SPF, and DKIM

It also fixes a minor syntax error in some GCP modules.
